### PR TITLE
Basic abstract class use case

### DIFF
--- a/app/src/main/java/com/developer/ivan/core/UseCase.kt
+++ b/app/src/main/java/com/developer/ivan/core/UseCase.kt
@@ -6,7 +6,7 @@ abstract class UseCase<Param, Return, Scope> where Scope : CoroutineScope
 {
     abstract suspend fun body(param: Param): Either<Failure,Return>
 
-    private fun execute(onResult: (Either<Failure,Return>)->Unit,param: Param,scope: CoroutineScope){
+    fun execute(onResult: (Either<Failure,Return>)->Unit,param: Param,scope: CoroutineScope){
 
         scope.launch {
             val deferredResult = async{body(param)}


### PR DESCRIPTION
close #6 

Added abstract class UseCase with Either structure.

**Example**

```
class MyUseCase: UseCase<ReturnType, MyParams, CoroutineScope)
{
  fun body(param: MyParam){
  //use case logic
 }
}
```
...

```
val myUseCase = MyUseCase()
myUseCase.execute({it.either(::handleFailure,::handleResult}, params, scope)
```