### PR TITLE
Added Failure class

### DIFF
--- a/app/src/main/java/com/developer/ivan/core/Failure.kt
+++ b/app/src/main/java/com/developer/ivan/core/Failure.kt
@@ -1,0 +1,11 @@
+package com.developer.ivan.core
+
+sealed class Failure
+{
+    object ConnectivityError: Failure()
+    object JsonException: Failure()
+
+    class ServerError(errorCode: Int): Failure()
+
+    abstract class FailureAbstract: Failure()
+}


### PR DESCRIPTION
closed #7

Added  ConnectivityError, JsonException, ServerError with argument and FailureAbstract.

FailureAbstract is an abstract class that can be inherited for flexibility for another types of Failures.

